### PR TITLE
fix: crypto implementations not being compiled

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -69,7 +69,6 @@ pub fn build(b: *std.Build) void {
     ssh2_lib.root_module.addCSourceFiles(.{ .files = ssh2_src, .root = upstream.path(""), .flags = ssh2_flags });
 
     if (mbedtls) {
-        ssh2_lib.root_module.addCSourceFile(.{ .file = upstream.path("src/mbedtls.c"), .flags = ssh2_flags });
         ssh2_lib.root_module.addCMacro("LIBSSH2_MBEDTLS", "1");
         ssh2_lib.linkSystemLibrary("mbedtls");
         ssh2_lib.linkSystemLibrary("mbedcrypto");
@@ -77,14 +76,12 @@ pub fn build(b: *std.Build) void {
     }
 
     if (openssl) {
-        ssh2_lib.root_module.addCSourceFile(.{ .file = upstream.path("src/openssl.c"), .flags = ssh2_flags });
         ssh2_lib.root_module.addCMacro("LIBSSH2_OPENSSL", "1");
         ssh2_lib.linkSystemLibrary("ssl");
         ssh2_lib.linkSystemLibrary("crypto");
     }
 
     if (wincng) {
-        ssh2_lib.root_module.addCSourceFile(.{ .file = upstream.path("src/wincng.c"), .flags = ssh2_flags });
         ssh2_lib.root_module.addCMacro("LIBSSH2_WINCNG", "1");
         // Windows system libs (zig handles names)
         ssh2_lib.linkSystemLibrary("bcrypt");
@@ -92,7 +89,6 @@ pub fn build(b: *std.Build) void {
     }
 
     if (libgcrypt) {
-        ssh2_lib.root_module.addCSourceFile(.{ .file = upstream.path("src/libgcrypt.c"), .flags = ssh2_flags });
         ssh2_lib.root_module.addCMacro("LIBSSH2_LIBGCRYPT", "1");
         ssh2_lib.linkSystemLibrary("gcrypt");
     }
@@ -136,6 +132,7 @@ pub const ssh2_src: []const []const u8 = &.{
     "src/userauth.c",
     "src/userauth_kbd_packet.c",
     "src/version.c",
+    "src/crypto.c",
 };
 
 pub const ssh2_flags: []const []const u8 = &.{};


### PR DESCRIPTION
Because of the `LIBSSH2_CRYPTO_C` ifdef at the top of [src/openssl.c](https://github.com/libssh2/libssh2/blob/libssh2-1.11.1/src/openssl.c#L42), [src/mbedtls.c](https://github.com/libssh2/libssh2/blob/libssh2-1.11.1/src/mbedtls.c#L40), [src/libgcrypt.c](https://github.com/libssh2/libssh2/blob/libssh2-1.11.1/src/libgcrypt.c#L41), [src/wincng.c](https://github.com/libssh2/libssh2/blob/libssh2-1.11.1/src/wincng.c#L41) these crypto backends couldn't be used.

It would fail with these kinds of error:
```
error: undefined symbol: _libssh2_mbedtls_random
    note: referenced by .zig-cache/o/11843e63979650ec3e09dac0b545db56/libssh2.a(.zig-cache/o/2cb63cf0ca6e9aa751f1df0888da2261/channel.o/):.text
    note: referenced by .zig-cache/o/11843e63979650ec3e09dac0b545db56/libssh2.a(.zig-cache/o/28a72c5e23a642bd413157731ed57289/kex.o/):.text
    note: referenced by .zig-cache/o/11843e63979650ec3e09dac0b545db56/libssh2.a(.zig-cache/o/ae98866eb50c1eab86ef8af28da13486/transport.o/):.text
error: undefined symbol: _libssh2_mbedtls_cipher_init
    note: referenced by .zig-cache/o/11843e63979650ec3e09dac0b545db56/libssh2.a(.zig-cache/o/8e6643d4a607c887ad66270bdc2bb433/crypt.o/):.text
error: undefined symbol: _libssh2_mbedtls_cipher_crypt
    note: referenced by .zig-cache/o/11843e63979650ec3e09dac0b545db56/libssh2.a(.zig-cache/o/8e6643d4a607c887ad66270bdc2bb433/crypt.o/):.text
error: undefined symbol: _libssh2_mbedtls_cipher_dtor
    note: referenced by .zig-cache/o/11843e63979650ec3e09dac0b545db56/libssh2.a(.zig-cache/o/8e6643d4a607c887ad66270bdc2bb433/crypt.o/):.text
error: undefined symbol: _libssh2_mbedtls_init
    note: referenced by .zig-cache/o/11843e63979650ec3e09dac0b545db56/libssh2.a(.zig-cache/o/a97e21cd704e51c71c5c9fc294fe88b6/global.o/):.text
error: undefined symbol: _libssh2_mbedtls_free
    note: referenced by .zig-cache/o/11843e63979650ec3e09dac0b545db56/libssh2.a(.zig-cache/o/a97e21cd704e51c71c5c9fc294fe88b6/global.o/):.text

...
```

FYI. After some additional investigating I noticed that this `LIBSSH2_CRYPTO_C` ifdef doesn't exist in the master branch of libssh2. Because it was removed with this commit https://github.com/libssh2/libssh2/commit/e0681cdba9980fcf7aa748509423e6fe5e7e29da. So when upgrading past libssh2-1.11.1 this part will need to be updated again.

Maybe as a future improvement CI/CD needs to be setup for this, so this kind of bug doesn't reoccur?