### PR TITLE
feat(linking): control link mode of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ const libssh2_dependency = b.dependency("libssh2", .{
     .strip = true, // Strip debug information (default=false)
     .linkage = .static, // Whether to link statically or dynamically (default=static)
     .@"crypto-backend" = .auto, // auto will to default to wincng on windows, openssl everywhere else. (default=auto)
+    .@"openssl-linkage" = .static, // each dependency's linkage can be configured to static/dynamic linking
 });
-```
-
-```
-
 ```


### PR DESCRIPTION
This PR adds support for individually controlling dependencies' link mode `static|dynamic` via `build.zig` as requested in #7 

### Examples

```zig
    const libssh2_dependency = b.dependency("libssh2", .{
        .target = target,
        .optimize = optimize,
        .@"crypto-backend" = .mbedtls,
        .@"mbedtls-linkage" = .static,
    });
    exe.linkLibrary(libssh2_dependency.artifact("ssh2"));
```

Will statically link `mbedtls`, `ldd` output:

```sh
# ldd zig-out/bin/example
linux-vdso.so.1 (0x00007f3fe1e81000)
libm.so.6 => /usr/lib/libm.so.6 (0x00007f3fe1d42000)
libc.so.6 => /usr/lib/libc.so.6 (0x00007f3fe1a00000)
/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f3fe1e83000)
```

Whereas dynamic linking:

```zig
    const libssh2_dependency = b.dependency("libssh2", .{
        .target = target,
        .optimize = optimize,
        .@"crypto-backend" = .mbedtls,
        .@"mbedtls-linkage" = .dynamic,
    });
    exe.linkLibrary(libssh2_dependency.artifact("ssh2"));
```

Will result in:

```sh
# ldd zig-out/bin/example
linux-vdso.so.1 (0x00007fdf6a024000)
libm.so.6 => /usr/lib/libm.so.6 (0x00007fdf69ee5000)
libc.so.6 => /usr/lib/libc.so.6 (0x00007fdf69c00000)
/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007fdf6a026000)
libmbedcrypto.so.16 => /usr/lib/libmbedcrypto.so.16 (0x00007fdf69e54000)
```

On my machine statically linking (debug build) resulted in an 11mb binary. Dynamically linking reduced it to 8.3mb.