### PR TITLE
Add option to skip linking against system libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,6 @@ const libssh2_dependency = b.dependency("libssh2", .{
     .strip = true, // Strip debug information (default=false)
     .linkage = .static, // Whether to link statically or dynamically (default=static)
     .@"crypto-backend" = .auto, // auto will to default to wincng on windows, openssl everywhere else. (default=auto)
+    .@"link-system-crypto-backend" = true, // If enabled will link against system libraries (default=true)
 });
 ```

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ const libssh2_dependency = b.dependency("libssh2", .{
 ```
 
 By default libssh2 will dynamically link against the crypto backend.
-This can be changed through system integration options, i.e. `-fsys` and `-fno-sys`
+This can be disable through the system integration options, i.e. `-fsys` and `-fno-sys`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ const libssh2_dependency = b.dependency("libssh2", .{
     .strip = true, // Strip debug information (default=false)
     .linkage = .static, // Whether to link statically or dynamically (default=static)
     .@"crypto-backend" = .auto, // auto will to default to wincng on windows, openssl everywhere else. (default=auto)
-    .@"openssl-linkage" = .static, // each dependency's linkage can be configured to static/dynamic linking
 });
 ```
+
+By default libssh2 will dynamically link against the crypto backend.
+This can be changed through system integration options, i.e. `-fsys` and `-fno-sys`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,3 @@ const libssh2_dependency = b.dependency("libssh2", .{
     .@"crypto-backend" = .auto, // auto will to default to wincng on windows, openssl everywhere else. (default=auto)
 });
 ```
-
-By default libssh2 will dynamically link against the crypto backend.
-This can be disable through the system integration options, i.e. `-fsys` and `-fno-sys`

--- a/build.zig
+++ b/build.zig
@@ -20,6 +20,7 @@ pub fn build(b: *std.Build) void {
     const pic = b.option(bool, "pie", "Produce Position Independent Code");
 
     const crypto_choice = b.option(CryptoBackend, "crypto-backend", "Crypto backend: auto|openssl|mbedtls|libgcrypt|wincng") orelse .auto;
+    const link_system_crypto = b.option(bool, "link-system-crypto-backend", "If true, library will link against system libraries") orelse true;
     const zlib = b.option(bool, "zlib", "Enable SSH payload compression (links zlib)") orelse false;
 
     const is_windows = target.result.os.tag == .windows;
@@ -70,43 +71,33 @@ pub fn build(b: *std.Build) void {
 
     if (mbedtls) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_MBEDTLS", "1");
-        if (b.systemIntegrationOption("mbedtls", .{ .default = true })) {
+        if (link_system_crypto) {
             ssh2_lib.linkSystemLibrary("mbedtls");
             ssh2_lib.linkSystemLibrary("mbedcrypto");
             ssh2_lib.linkSystemLibrary("mbedx509");
-        } else {
-            // TODO: Add lazy dependency to build.zig.zon and statically link against library.
-            // For now it's the users resposibility to compile and link against the library
         }
     }
 
     if (openssl) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_OPENSSL", "1");
-        if (b.systemIntegrationOption("openssl", .{ .default = true })) {
+        if (link_system_crypto) {
             ssh2_lib.linkSystemLibrary("ssl");
             ssh2_lib.linkSystemLibrary("crypto");
-        } else {
-            // TODO: Add lazy dependency to build.zig.zon and statically link against library.
-            // For now it's the users resposibility to compile and link against the library
         }
     }
 
     if (wincng) {
-        // There is no need to provide `b.systemIntegrationOption` here,
-        // because on windows this library MUST be dynamically linked.
-
         ssh2_lib.root_module.addCMacro("LIBSSH2_WINCNG", "1");
-        ssh2_lib.linkSystemLibrary2("bcrypt", .{});
-        ssh2_lib.linkSystemLibrary2("ncrypt", .{});
+        if (link_system_crypto) {
+            ssh2_lib.linkSystemLibrary("bcrypt");
+            ssh2_lib.linkSystemLibrary("ncrypt");
+        }
     }
 
     if (libgcrypt) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_LIBGCRYPT", "1");
-        if (b.systemIntegrationOption("libgcrypt", .{ .default = true })) {
+        if (link_system_crypto) {
             ssh2_lib.linkSystemLibrary("gcrypt");
-        } else {
-            // TODO: Add lazy dependency to build.zig.zon and statically link against library.
-            // For now it's the users resposibility to compile and link against the library
         }
     }
 

--- a/build.zig
+++ b/build.zig
@@ -21,10 +21,6 @@ pub fn build(b: *std.Build) void {
 
     const crypto_choice = b.option(CryptoBackend, "crypto-backend", "Crypto backend: auto|openssl|mbedtls|libgcrypt|wincng") orelse .auto;
     const zlib = b.option(bool, "zlib", "Enable SSH payload compression (links zlib)") orelse false;
-    const mbedtls_linkage = b.option(std.builtin.LinkMode, "mbedtls-linkage", "static|dynamic") orelse .static;
-    const openssl_linkage = b.option(std.builtin.LinkMode, "openssl-linkage", "static|dynamic") orelse .static;
-    const wincng_linkage = b.option(std.builtin.LinkMode, "wincng-linkage", "static|dynamic") orelse .static;
-    const gcrypt_linkage = b.option(std.builtin.LinkMode, "gcrypt-linkage", "static|dynamic") orelse .static;
 
     const is_windows = target.result.os.tag == .windows;
     const mbedtls = crypto_choice == .mbedtls;
@@ -74,26 +70,44 @@ pub fn build(b: *std.Build) void {
 
     if (mbedtls) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_MBEDTLS", "1");
-        ssh2_lib.linkSystemLibrary2("mbedtls", .{ .preferred_link_mode = mbedtls_linkage });
-        ssh2_lib.linkSystemLibrary2("mbedcrypto", .{ .preferred_link_mode = mbedtls_linkage });
-        ssh2_lib.linkSystemLibrary2("mbedx509", .{ .preferred_link_mode = mbedtls_linkage });
+        if (b.systemIntegrationOption("mbedtls", .{ .default = true })) {
+            ssh2_lib.linkSystemLibrary("mbedtls");
+            ssh2_lib.linkSystemLibrary("mbedcrypto");
+            ssh2_lib.linkSystemLibrary("mbedx509");
+        } else {
+            // TODO: Add lazy dependency to build.zig.zon for linking statically.
+            // For now it's the users resposibility to compile and statically link against library
+        }
     }
 
     if (openssl) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_OPENSSL", "1");
-        ssh2_lib.linkSystemLibrary2("ssl", .{ .preferred_link_mode = openssl_linkage });
-        ssh2_lib.linkSystemLibrary2("crypto", .{ .preferred_link_mode = openssl_linkage });
+        if (b.systemIntegrationOption("openssl", .{ .default = true })) {
+            ssh2_lib.linkSystemLibrary("ssl");
+            ssh2_lib.linkSystemLibrary("crypto");
+        } else {
+            // TODO: Add lazy dependency to build.zig.zon for linking statically.
+            // For now it's the users resposibility to compile and statically link against library
+        }
     }
 
     if (wincng) {
+        // There is no need to provide `b.systemIntegrationOption` here,
+        // because on windows this library MUST be dynamically linked. There is no static version.
+
         ssh2_lib.root_module.addCMacro("LIBSSH2_WINCNG", "1");
-        ssh2_lib.linkSystemLibrary2("bcrypt", .{ .preferred_link_mode = wincng_linkage });
-        ssh2_lib.linkSystemLibrary2("ncrypt", .{ .preferred_link_mode = wincng_linkage });
+        ssh2_lib.linkSystemLibrary2("bcrypt", .{});
+        ssh2_lib.linkSystemLibrary2("ncrypt", .{});
     }
 
     if (libgcrypt) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_LIBGCRYPT", "1");
-        ssh2_lib.linkSystemLibrary2("gcrypt", .{ .preferred_link_mode = gcrypt_linkage });
+        if (b.systemIntegrationOption("libgcrypt", .{ .default = true })) {
+            ssh2_lib.linkSystemLibrary("gcrypt");
+        } else {
+            // TODO: Add lazy dependency to build.zig.zon for linking statically.
+            // For now it's the users resposibility to compile and statically link against library
+        }
     }
 
     if (zlib) {

--- a/build.zig
+++ b/build.zig
@@ -75,8 +75,8 @@ pub fn build(b: *std.Build) void {
             ssh2_lib.linkSystemLibrary("mbedcrypto");
             ssh2_lib.linkSystemLibrary("mbedx509");
         } else {
-            // TODO: Add lazy dependency to build.zig.zon for linking statically.
-            // For now it's the users resposibility to compile and statically link against library
+            // TODO: Add lazy dependency to build.zig.zon and statically link against library.
+            // For now it's the users resposibility to compile and link against the library
         }
     }
 
@@ -86,14 +86,14 @@ pub fn build(b: *std.Build) void {
             ssh2_lib.linkSystemLibrary("ssl");
             ssh2_lib.linkSystemLibrary("crypto");
         } else {
-            // TODO: Add lazy dependency to build.zig.zon for linking statically.
-            // For now it's the users resposibility to compile and statically link against library
+            // TODO: Add lazy dependency to build.zig.zon and statically link against library.
+            // For now it's the users resposibility to compile and link against the library
         }
     }
 
     if (wincng) {
         // There is no need to provide `b.systemIntegrationOption` here,
-        // because on windows this library MUST be dynamically linked. There is no static version.
+        // because on windows this library MUST be dynamically linked.
 
         ssh2_lib.root_module.addCMacro("LIBSSH2_WINCNG", "1");
         ssh2_lib.linkSystemLibrary2("bcrypt", .{});
@@ -105,8 +105,8 @@ pub fn build(b: *std.Build) void {
         if (b.systemIntegrationOption("libgcrypt", .{ .default = true })) {
             ssh2_lib.linkSystemLibrary("gcrypt");
         } else {
-            // TODO: Add lazy dependency to build.zig.zon for linking statically.
-            // For now it's the users resposibility to compile and statically link against library
+            // TODO: Add lazy dependency to build.zig.zon and statically link against library.
+            // For now it's the users resposibility to compile and link against the library
         }
     }
 

--- a/build.zig
+++ b/build.zig
@@ -72,32 +72,32 @@ pub fn build(b: *std.Build) void {
     if (mbedtls) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_MBEDTLS", "1");
         if (link_system_crypto) {
-            ssh2_lib.linkSystemLibrary("mbedtls");
-            ssh2_lib.linkSystemLibrary("mbedcrypto");
-            ssh2_lib.linkSystemLibrary("mbedx509");
+            ssh2_lib.root_module.linkSystemLibrary("mbedtls");
+            ssh2_lib.root_module.linkSystemLibrary("mbedcrypto");
+            ssh2_lib.root_module.linkSystemLibrary("mbedx509");
         }
     }
 
     if (openssl) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_OPENSSL", "1");
         if (link_system_crypto) {
-            ssh2_lib.linkSystemLibrary("ssl");
-            ssh2_lib.linkSystemLibrary("crypto");
+            ssh2_lib.root_module.linkSystemLibrary("ssl");
+            ssh2_lib.root_module.linkSystemLibrary("crypto");
         }
     }
 
     if (wincng) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_WINCNG", "1");
         if (link_system_crypto) {
-            ssh2_lib.linkSystemLibrary("bcrypt");
-            ssh2_lib.linkSystemLibrary("ncrypt");
+            ssh2_lib.root_module.linkSystemLibrary("bcrypt");
+            ssh2_lib.root_module.linkSystemLibrary("ncrypt");
         }
     }
 
     if (libgcrypt) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_LIBGCRYPT", "1");
         if (link_system_crypto) {
-            ssh2_lib.linkSystemLibrary("gcrypt");
+            ssh2_lib.root_module.linkSystemLibrary("gcrypt");
         }
     }
 

--- a/build.zig
+++ b/build.zig
@@ -72,32 +72,32 @@ pub fn build(b: *std.Build) void {
     if (mbedtls) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_MBEDTLS", "1");
         if (link_system_crypto) {
-            ssh2_lib.root_module.linkSystemLibrary("mbedtls");
-            ssh2_lib.root_module.linkSystemLibrary("mbedcrypto");
-            ssh2_lib.root_module.linkSystemLibrary("mbedx509");
+            ssh2_lib.root_module.linkSystemLibrary("mbedtls", .{});
+            ssh2_lib.root_module.linkSystemLibrary("mbedcrypto", .{});
+            ssh2_lib.root_module.linkSystemLibrary("mbedx509", .{});
         }
     }
 
     if (openssl) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_OPENSSL", "1");
         if (link_system_crypto) {
-            ssh2_lib.root_module.linkSystemLibrary("ssl");
-            ssh2_lib.root_module.linkSystemLibrary("crypto");
+            ssh2_lib.root_module.linkSystemLibrary("ssl", .{});
+            ssh2_lib.root_module.linkSystemLibrary("crypto", .{});
         }
     }
 
     if (wincng) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_WINCNG", "1");
         if (link_system_crypto) {
-            ssh2_lib.root_module.linkSystemLibrary("bcrypt");
-            ssh2_lib.root_module.linkSystemLibrary("ncrypt");
+            ssh2_lib.root_module.linkSystemLibrary("bcrypt", .{});
+            ssh2_lib.root_module.linkSystemLibrary("ncrypt", .{});
         }
     }
 
     if (libgcrypt) {
         ssh2_lib.root_module.addCMacro("LIBSSH2_LIBGCRYPT", "1");
         if (link_system_crypto) {
-            ssh2_lib.root_module.linkSystemLibrary("gcrypt");
+            ssh2_lib.root_module.linkSystemLibrary("gcrypt", .{});
         }
     }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "N-V-__8AAATRLQBu_rNy4X2UK6RtcdYK_yAzkV6OcCqgo5aK",
         },
         .zlib = .{
-            .url = "git+https://github.com/allyourcodebase/zlib.git#61e7df7e996ec5a5f13a653db3c419adb340d6ef",
-            .hash = "zlib-1.3.1-ZZQ7lbYMAAB1hTSOKSXAKAgHsfDcyWNH_37ojw5WSpgR",
+            .url = "git+https://github.com/allyourcodebase/zlib.git#3599c16d41dbe749ae51b0ff7ab864c61adc779a",
+            .hash = "zlib-1.3.1-ZZQ7lc8NAABUbHzDe_cSWboCqMbrLkVwvFkKnojgeiT2",
             .lazy = true,
         },
     },


### PR DESCRIPTION
Resolves https://github.com/allyourcodebase/libssh2/issues/7

Here is an example for how the build.zig needs to look if you are using `-fno-sys=mbedtls`:
```zig
const mbedtls_dependency = b.dependency("mbedtls", .{
    .target = target,
    .optimize = optimize,
});

const libssh2_dependency = b.dependency("libssh2", .{
    .target = target,
    .optimize = optimize,
    .strip = optimize != .Debug,
    .@"crypto-backend" = .mbedtls,
});
const libssh2_artifact = libssh2_dependency.artifact("ssh2");
 
// This line is very important, it's important to link mbedtls with libssh2. Not with root_module.
// This is a very easy mistake to make.
libssh2_artifact.linkLibrary(mbedtls_dependency.artifact("mbedtls"));

root_module.linkLibrary(libssh2_artifact);

const exe = b.addExecutable(.{
    .name = "resource_tracker",
    .root_module = root_module
});
```